### PR TITLE
Build updates

### DIFF
--- a/wrims_v2/wrimsv2_plugin/WRIMS2_plugin.launch
+++ b/wrims_v2/wrimsv2_plugin/WRIMS2_plugin.launch
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+<setAttribute key="additional_plugins"/>
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="true"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearws" value="false"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/WRIMS2_plugin"/>
+<booleanAttribute key="default" value="true"/>
+<stringAttribute key="featureDefaultLocation" value="workspace"/>
+<stringAttribute key="featurePluginResolution" value="workspace"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../runtime-WRIMS2_plugin"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m -Xmx512m -XX:MaxPermSize=128m -Djava.library.path=&quot;lib&quot;"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.platform.ide"/>
+<setAttribute key="selected_features">
+<setEntry value="com.collabnet.subversion.merge.feature:default"/>
+<setEntry value="gov.ca.dwr.wresl.feature:default"/>
+<setEntry value="org.eclipse.cvs:default"/>
+<setEntry value="org.eclipse.egit.mylyn:default"/>
+<setEntry value="org.eclipse.egit.source:default"/>
+<setEntry value="org.eclipse.egit:default"/>
+<setEntry value="org.eclipse.emf.mwe.core.source:default"/>
+<setEntry value="org.eclipse.emf.mwe.core:default"/>
+<setEntry value="org.eclipse.emf.mwe.doc:default"/>
+<setEntry value="org.eclipse.emf.mwe.sdk:default"/>
+<setEntry value="org.eclipse.emf.mwe.ui.source:default"/>
+<setEntry value="org.eclipse.emf.mwe.ui:default"/>
+<setEntry value="org.eclipse.emf.mwe2.language.sdk.source:default"/>
+<setEntry value="org.eclipse.emf.mwe2.language.sdk:default"/>
+<setEntry value="org.eclipse.emf.mwe2.runtime.sdk.source:default"/>
+<setEntry value="org.eclipse.emf.mwe2.runtime.sdk:default"/>
+<setEntry value="org.eclipse.epp.mpc:default"/>
+<setEntry value="org.eclipse.epp.package.common.feature:default"/>
+<setEntry value="org.eclipse.epp.package.rcp.feature:default"/>
+<setEntry value="org.eclipse.epp.usagedata.feature:default"/>
+<setEntry value="org.eclipse.equinox.p2.core.feature.source:default"/>
+<setEntry value="org.eclipse.equinox.p2.core.feature:default"/>
+<setEntry value="org.eclipse.equinox.p2.discovery.feature:default"/>
+<setEntry value="org.eclipse.equinox.p2.extras.feature.source:default"/>
+<setEntry value="org.eclipse.equinox.p2.extras.feature:default"/>
+<setEntry value="org.eclipse.equinox.p2.rcp.feature.source:default"/>
+<setEntry value="org.eclipse.equinox.p2.rcp.feature:default"/>
+<setEntry value="org.eclipse.equinox.p2.user.ui.source:default"/>
+<setEntry value="org.eclipse.equinox.p2.user.ui:default"/>
+<setEntry value="org.eclipse.help:default"/>
+<setEntry value="org.eclipse.jdt:default"/>
+<setEntry value="org.eclipse.jgit.source:default"/>
+<setEntry value="org.eclipse.jgit:default"/>
+<setEntry value="org.eclipse.mylyn.bugzilla_feature:default"/>
+<setEntry value="org.eclipse.mylyn.context_feature:default"/>
+<setEntry value="org.eclipse.mylyn.github.feature:default"/>
+<setEntry value="org.eclipse.mylyn.ide_feature:default"/>
+<setEntry value="org.eclipse.mylyn.java_feature:default"/>
+<setEntry value="org.eclipse.mylyn.pde_feature:default"/>
+<setEntry value="org.eclipse.mylyn.team_feature:default"/>
+<setEntry value="org.eclipse.mylyn.wikitext_feature:default"/>
+<setEntry value="org.eclipse.mylyn_feature:default"/>
+<setEntry value="org.eclipse.pde:default"/>
+<setEntry value="org.eclipse.platform.source:default"/>
+<setEntry value="org.eclipse.platform:default"/>
+<setEntry value="org.eclipse.rap.tooling:default"/>
+<setEntry value="org.eclipse.rcp.source:default"/>
+<setEntry value="org.eclipse.rcp:default"/>
+<setEntry value="org.eclipse.wst.common_core.feature:default"/>
+<setEntry value="org.eclipse.wst.common_ui.feature:default"/>
+<setEntry value="org.eclipse.wst.xml_core.feature:default"/>
+<setEntry value="org.eclipse.wst.xml_ui.feature:default"/>
+<setEntry value="org.eclipse.wst.xml_userdoc.feature:default"/>
+<setEntry value="org.eclipse.xpand.all:default"/>
+<setEntry value="org.eclipse.xpand.doc:default"/>
+<setEntry value="org.eclipse.xpand.examples.source:default"/>
+<setEntry value="org.eclipse.xpand.examples:default"/>
+<setEntry value="org.eclipse.xpand.sdk:default"/>
+<setEntry value="org.eclipse.xpand.source:default"/>
+<setEntry value="org.eclipse.xpand.support:default"/>
+<setEntry value="org.eclipse.xpand.ui.source:default"/>
+<setEntry value="org.eclipse.xpand.ui:default"/>
+<setEntry value="org.eclipse.xpand:default"/>
+<setEntry value="org.eclipse.xtend.backend.sdk:default"/>
+<setEntry value="org.eclipse.xtend.backend.source:default"/>
+<setEntry value="org.eclipse.xtend.backend.ui.source:default"/>
+<setEntry value="org.eclipse.xtend.backend.ui:default"/>
+<setEntry value="org.eclipse.xtend.backend.uml2types.source:default"/>
+<setEntry value="org.eclipse.xtend.backend.uml2types:default"/>
+<setEntry value="org.eclipse.xtend.backend.xsdtypes.source:default"/>
+<setEntry value="org.eclipse.xtend.backend.xsdtypes:default"/>
+<setEntry value="org.eclipse.xtend.backend:default"/>
+<setEntry value="org.eclipse.xtend.dependencies.source:default"/>
+<setEntry value="org.eclipse.xtend.dependencies:default"/>
+<setEntry value="org.eclipse.xtend.gwt:default"/>
+<setEntry value="org.eclipse.xtend.m2e:default"/>
+<setEntry value="org.eclipse.xtend.middleend.xpand:default"/>
+<setEntry value="org.eclipse.xtend.middleend.xtend:default"/>
+<setEntry value="org.eclipse.xtend.sdk:default"/>
+<setEntry value="org.eclipse.xtend.source:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.emf.source:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.emf:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.uml2.source:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.uml2:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.xsd.source:default"/>
+<setEntry value="org.eclipse.xtend.typesystem.xsd:default"/>
+<setEntry value="org.eclipse.xtend.ui.source:default"/>
+<setEntry value="org.eclipse.xtend.ui:default"/>
+<setEntry value="org.eclipse.xtend:default"/>
+<setEntry value="org.eclipse.xtext.docs:default"/>
+<setEntry value="org.eclipse.xtext.examples.source:default"/>
+<setEntry value="org.eclipse.xtext.examples:default"/>
+<setEntry value="org.eclipse.xtext.gwt:default"/>
+<setEntry value="org.eclipse.xtext.runtime.source:default"/>
+<setEntry value="org.eclipse.xtext.runtime:default"/>
+<setEntry value="org.eclipse.xtext.sdk:default"/>
+<setEntry value="org.eclipse.xtext.ui.source:default"/>
+<setEntry value="org.eclipse.xtext.ui:default"/>
+<setEntry value="org.eclipse.xtext.xbase.lib.source:default"/>
+<setEntry value="org.eclipse.xtext.xbase.lib:default"/>
+<setEntry value="org.eclipse.xtext.xbase.source:default"/>
+<setEntry value="org.eclipse.xtext.xbase:default"/>
+<setEntry value="org.eclipse.xtext.xtext.ui.source:default"/>
+<setEntry value="org.eclipse.xtext.xtext.ui:default"/>
+<setEntry value="org.testng.eclipse:default"/>
+<setEntry value="org.tigris.subversion.clientadapter.feature:default"/>
+<setEntry value="org.tigris.subversion.clientadapter.javahl.feature:default"/>
+<setEntry value="org.tigris.subversion.subclipse.graph.feature:default"/>
+<setEntry value="org.tigris.subversion.subclipse.mylyn:default"/>
+<setEntry value="org.tigris.subversion.subclipse:default"/>
+</setAttribute>
+<stringAttribute key="selected_target_plugins" value="com.google.gson@default:default,com.google.guava@default:default,com.google.inject@default:default,com.ibm.icu@default:default,com.jcraft.jsch*0.1.50.v201403120620@default:default,com.jcraft.jsch*0.1.51.v201410302000@default:default,javax.inject@default:default,javax.servlet.jsp@default:default,javax.servlet@default:default,javax.xml@default:default,org.antlr.runtime@default:default,org.apache.ant@default:default,org.apache.commons.cli@default:default,org.apache.commons.codec@default:default,org.apache.commons.httpclient@default:default,org.apache.commons.lang@default:default,org.apache.commons.logging@default:default,org.apache.httpcomponents.httpclient@default:default,org.apache.httpcomponents.httpcore@default:default,org.apache.log4j@default:default,org.apache.lucene.analysis@default:default,org.apache.lucene.core@default:default,org.apache.ws.commons.util@default:default,org.apache.xerces@default:default,org.apache.xml.resolver@default:default,org.apache.xml.serializer@default:default,org.apache.xmlrpc@default:default,org.eclipse.ant.core@default:default,org.eclipse.ant.launching@default:default,org.eclipse.ant.ui@default:default,org.eclipse.compare.core@default:default,org.eclipse.compare.win32@default:default,org.eclipse.compare@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.beans@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.externaltools@default:default,org.eclipse.core.filebuffers@default:default,org.eclipse.core.filesystem.win32.x86@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.net.win32.x86@default:false,org.eclipse.core.net@default:default,org.eclipse.core.resources.win32.x86@default:false,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:false,org.eclipse.core.runtime.compatibility@default:default,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.cvs@default:default,org.eclipse.debug.core@default:default,org.eclipse.debug.ui@default:default,org.eclipse.draw2d@default:default,org.eclipse.ecf.filetransfer@default:default,org.eclipse.ecf.identity@default:default,org.eclipse.ecf.provider.filetransfer.ssl@default:false,org.eclipse.ecf.provider.filetransfer@default:default,org.eclipse.ecf.ssl@default:false,org.eclipse.ecf@default:default,org.eclipse.egit.core@default:default,org.eclipse.egit.doc@default:default,org.eclipse.egit.mylyn.ui@default:default,org.eclipse.egit.ui@default:default,org.eclipse.egit@default:default,org.eclipse.emf.codegen.ecore@default:default,org.eclipse.emf.codegen@default:default,org.eclipse.emf.common.ui@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.converter@default:default,org.eclipse.emf.databinding.edit@default:default,org.eclipse.emf.databinding@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.edit@default:default,org.eclipse.emf.ecore.editor@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.emf.edit.ui@default:default,org.eclipse.emf.edit@default:default,org.eclipse.emf.generic.editor@default:default,org.eclipse.emf.importer@default:default,org.eclipse.emf.mapping.ecore2xml@default:default,org.eclipse.emf.mwe.core@default:default,org.eclipse.emf.mwe.ui@default:default,org.eclipse.emf.mwe.utils@default:default,org.eclipse.emf.mwe2.language.ui@default:default,org.eclipse.emf.mwe2.language@default:default,org.eclipse.emf.mwe2.launch@default:default,org.eclipse.emf.mwe2.lib@default:default,org.eclipse.emf.mwe2.runtime@default:default,org.eclipse.epp.mpc.core@default:default,org.eclipse.epp.mpc.help.ui@default:default,org.eclipse.epp.mpc.ui@default:default,org.eclipse.epp.package.rcp@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.concurrent@default:default,org.eclipse.equinox.ds@1:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.frameworkadmin.equinox@default:default,org.eclipse.equinox.frameworkadmin@default:default,org.eclipse.equinox.http.jetty@default:default,org.eclipse.equinox.http.registry@default:default,org.eclipse.equinox.http.servlet@default:default,org.eclipse.equinox.jsp.jasper.registry@default:default,org.eclipse.equinox.jsp.jasper@default:default,org.eclipse.equinox.launcher.win32.win32.x86@default:false,org.eclipse.equinox.launcher@default:default,org.eclipse.equinox.p2.artifact.repository@default:default,org.eclipse.equinox.p2.console@default:default,org.eclipse.equinox.p2.core@default:default,org.eclipse.equinox.p2.director.app@default:default,org.eclipse.equinox.p2.director@default:default,org.eclipse.equinox.p2.directorywatcher@default:default,org.eclipse.equinox.p2.discovery.compatibility@default:default,org.eclipse.equinox.p2.discovery@default:default,org.eclipse.equinox.p2.engine@default:default,org.eclipse.equinox.p2.extensionlocation@default:default,org.eclipse.equinox.p2.garbagecollector@default:default,org.eclipse.equinox.p2.jarprocessor@default:default,org.eclipse.equinox.p2.metadata.repository@default:default,org.eclipse.equinox.p2.metadata@default:default,org.eclipse.equinox.p2.operations@default:default,org.eclipse.equinox.p2.publisher.eclipse@default:default,org.eclipse.equinox.p2.publisher@default:default,org.eclipse.equinox.p2.ql@default:default,org.eclipse.equinox.p2.reconciler.dropins@default:default,org.eclipse.equinox.p2.repository.tools@default:default,org.eclipse.equinox.p2.repository@default:default,org.eclipse.equinox.p2.touchpoint.eclipse@default:default,org.eclipse.equinox.p2.touchpoint.natives@default:default,org.eclipse.equinox.p2.transport.ecf@default:default,org.eclipse.equinox.p2.ui.discovery@default:default,org.eclipse.equinox.p2.ui.importexport@default:default,org.eclipse.equinox.p2.ui.sdk.scheduler@default:default,org.eclipse.equinox.p2.ui.sdk@default:default,org.eclipse.equinox.p2.ui@default:default,org.eclipse.equinox.p2.updatechecker@default:default,org.eclipse.equinox.p2.updatesite@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.security.ui@default:default,org.eclipse.equinox.security.win32.x86@default:false,org.eclipse.equinox.security@default:default,org.eclipse.equinox.simpleconfigurator.manipulator@default:default,org.eclipse.equinox.simpleconfigurator@1:true,org.eclipse.equinox.util@default:default,org.eclipse.gef@default:default,org.eclipse.help.base@default:default,org.eclipse.help.ui@default:default,org.eclipse.help.webapp@default:default,org.eclipse.help@default:default,org.eclipse.jdt.annotation*1.1.0.v20140129-1625@default:default,org.eclipse.jdt.annotation*2.0.0.v20140415-1436@default:default,org.eclipse.jdt.apt.core@default:default,org.eclipse.jdt.apt.pluggable.core@default:default,org.eclipse.jdt.apt.ui@default:default,org.eclipse.jdt.compiler.apt@default:false,org.eclipse.jdt.compiler.tool@default:false,org.eclipse.jdt.core.manipulation@default:default,org.eclipse.jdt.core@default:default,org.eclipse.jdt.debug.ui@default:default,org.eclipse.jdt.debug@default:default,org.eclipse.jdt.doc.user@default:default,org.eclipse.jdt.junit.core@default:default,org.eclipse.jdt.junit.runtime@default:default,org.eclipse.jdt.junit4.runtime@default:default,org.eclipse.jdt.junit@default:default,org.eclipse.jdt.launching@default:default,org.eclipse.jdt.ui@default:default,org.eclipse.jdt@default:default,org.eclipse.jem.util@default:default,org.eclipse.jface.databinding@default:default,org.eclipse.jface.text@default:default,org.eclipse.jface@default:default,org.eclipse.jgit@default:default,org.eclipse.jsch.core@default:default,org.eclipse.jsch.ui@default:default,org.eclipse.ltk.core.refactoring@default:default,org.eclipse.ltk.ui.refactoring@default:default,org.eclipse.mylyn.bugzilla.core@default:default,org.eclipse.mylyn.bugzilla.ide@default:default,org.eclipse.mylyn.bugzilla.ui@default:default,org.eclipse.mylyn.commons.core@default:default,org.eclipse.mylyn.commons.net@default:default,org.eclipse.mylyn.commons.screenshots@default:default,org.eclipse.mylyn.commons.ui@default:default,org.eclipse.mylyn.commons.xmlrpc@default:default,org.eclipse.mylyn.context.core@default:default,org.eclipse.mylyn.context.ui@default:default,org.eclipse.mylyn.discovery.core@default:default,org.eclipse.mylyn.discovery.ui@default:default,org.eclipse.mylyn.help.ui@default:default,org.eclipse.mylyn.ide.ant@default:default,org.eclipse.mylyn.ide.ui@default:default,org.eclipse.mylyn.java.tasks@default:default,org.eclipse.mylyn.java.ui@default:default,org.eclipse.mylyn.monitor.core@default:default,org.eclipse.mylyn.monitor.ui@default:default,org.eclipse.mylyn.pde.ui@default:default,org.eclipse.mylyn.resources.ui@default:default,org.eclipse.mylyn.tasks.bugs@default:default,org.eclipse.mylyn.tasks.core@default:default,org.eclipse.mylyn.tasks.search@default:default,org.eclipse.mylyn.tasks.ui@default:default,org.eclipse.mylyn.team.cvs@default:default,org.eclipse.mylyn.team.ui@default:default,org.eclipse.mylyn.wikitext.confluence.core@default:default,org.eclipse.mylyn.wikitext.confluence.ui@default:default,org.eclipse.mylyn.wikitext.core@default:default,org.eclipse.mylyn.wikitext.help.ui@default:default,org.eclipse.mylyn.wikitext.mediawiki.core@default:default,org.eclipse.mylyn.wikitext.mediawiki.ui@default:default,org.eclipse.mylyn.wikitext.tasks.ui@default:default,org.eclipse.mylyn.wikitext.textile.core@default:default,org.eclipse.mylyn.wikitext.textile.ui@default:default,org.eclipse.mylyn.wikitext.tracwiki.core@default:default,org.eclipse.mylyn.wikitext.tracwiki.ui@default:default,org.eclipse.mylyn.wikitext.twiki.core@default:default,org.eclipse.mylyn.wikitext.twiki.ui@default:default,org.eclipse.mylyn.wikitext.ui@default:default,org.eclipse.osgi.services@default:default,org.eclipse.osgi.util@default:default,org.eclipse.osgi@-1:true,org.eclipse.pde.api.tools.ui@default:default,org.eclipse.pde.api.tools@default:default,org.eclipse.pde.build@default:default,org.eclipse.pde.core@default:default,org.eclipse.pde.doc.user@default:default,org.eclipse.pde.ds.core@default:default,org.eclipse.pde.ds.ui@default:default,org.eclipse.pde.junit.runtime@default:default,org.eclipse.pde.launching@default:default,org.eclipse.pde.runtime@default:default,org.eclipse.pde.ua.core@default:default,org.eclipse.pde.ua.ui@default:default,org.eclipse.pde.ui.templates@default:default,org.eclipse.pde.ui@default:default,org.eclipse.pde@default:default,org.eclipse.platform.doc.isv@default:default,org.eclipse.platform.doc.user@default:default,org.eclipse.platform@default:default,org.eclipse.rcp@default:default,org.eclipse.search@default:default,org.eclipse.swt.win32.win32.x86@default:false,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.team.cvs.core@default:default,org.eclipse.team.cvs.ssh2@default:default,org.eclipse.team.cvs.ui@default:default,org.eclipse.team.ui@default:default,org.eclipse.text@default:default,org.eclipse.ui.browser@default:default,org.eclipse.ui.cheatsheets@default:default,org.eclipse.ui.console@default:default,org.eclipse.ui.editors@default:default,org.eclipse.ui.externaltools@default:default,org.eclipse.ui.forms@default:default,org.eclipse.ui.ide.application@default:default,org.eclipse.ui.ide@default:default,org.eclipse.ui.intro.universal@default:default,org.eclipse.ui.intro@default:default,org.eclipse.ui.navigator.resources@default:default,org.eclipse.ui.navigator@default:default,org.eclipse.ui.net@default:default,org.eclipse.ui.views.log@default:default,org.eclipse.ui.views.properties.tabbed@default:default,org.eclipse.ui.views@default:default,org.eclipse.ui.win32@default:false,org.eclipse.ui.workbench.texteditor@default:default,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:default,org.eclipse.uml2.codegen.ecore@default:default,org.eclipse.uml2.common@default:default,org.eclipse.uml2.types@default:default,org.eclipse.uml2.uml.ecore.importer@default:default,org.eclipse.uml2.uml.resources@default:default,org.eclipse.uml2.uml@default:default,org.eclipse.update.configurator@3:true,org.eclipse.wst.common.core@default:default,org.eclipse.wst.common.emf@default:default,org.eclipse.wst.common.emfworkbench.integration@default:default,org.eclipse.wst.common.environment@default:default,org.eclipse.wst.common.frameworks.ui@default:default,org.eclipse.wst.common.frameworks@default:default,org.eclipse.wst.common.infopop@default:default,org.eclipse.wst.common.modulecore.ui@default:default,org.eclipse.wst.common.modulecore@default:default,org.eclipse.wst.common.project.facet.core@default:default,org.eclipse.wst.common.snippets@default:default,org.eclipse.wst.common.ui@default:default,org.eclipse.wst.common.uriresolver@default:default,org.eclipse.wst.dtd.core@default:default,org.eclipse.wst.dtd.ui.infopop@default:default,org.eclipse.wst.dtd.ui@default:default,org.eclipse.wst.dtdeditor.doc.user@default:default,org.eclipse.wst.internet.cache@default:default,org.eclipse.wst.server.core@default:default,org.eclipse.wst.sse.core@default:default,org.eclipse.wst.sse.doc.user@default:default,org.eclipse.wst.sse.ui.infopop@default:default,org.eclipse.wst.sse.ui@default:default,org.eclipse.wst.standard.schemas@default:default,org.eclipse.wst.validation.infopop@default:default,org.eclipse.wst.validation.ui@default:default,org.eclipse.wst.validation@default:default,org.eclipse.wst.xml.core@default:default,org.eclipse.wst.xml.ui.infopop@default:default,org.eclipse.wst.xml.ui@default:default,org.eclipse.wst.xmleditor.doc.user@default:default,org.eclipse.wst.xsd.core@default:default,org.eclipse.wst.xsd.ui@default:default,org.eclipse.wst.xsdeditor.doc.user@default:default,org.eclipse.xpand.activities@default:default,org.eclipse.xpand.doc@default:default,org.eclipse.xpand.examples@default:default,org.eclipse.xpand.support.cdt@default:default,org.eclipse.xpand.ui@default:default,org.eclipse.xpand@default:default,org.eclipse.xsd.edit@default:default,org.eclipse.xsd@default:default,org.eclipse.xtend.backend.compiler@default:default,org.eclipse.xtend.backend.ui@default:default,org.eclipse.xtend.backend.uml2types@default:default,org.eclipse.xtend.backend.xsdtypes@default:default,org.eclipse.xtend.backend@default:default,org.eclipse.xtend.check.ui@default:default,org.eclipse.xtend.core@default:default,org.eclipse.xtend.doc@default:default,org.eclipse.xtend.examples@default:default,org.eclipse.xtend.ide@default:default,org.eclipse.xtend.lib*2.8.3.v201506010551@default:default,org.eclipse.xtend.lib*2.9.0.v201507170721@default:default,org.eclipse.xtend.lib.gwt@default:default,org.eclipse.xtend.m2e@default:default,org.eclipse.xtend.middleend.xpand@default:default,org.eclipse.xtend.middleend.xtend@default:default,org.eclipse.xtend.profiler@default:default,org.eclipse.xtend.shared.ui@default:default,org.eclipse.xtend.typesystem.emf.ui@default:default,org.eclipse.xtend.typesystem.emf@default:default,org.eclipse.xtend.typesystem.uml2.ui@default:default,org.eclipse.xtend.typesystem.uml2@default:default,org.eclipse.xtend.typesystem.xsd.ui@default:default,org.eclipse.xtend.typesystem.xsd@default:default,org.eclipse.xtend.ui@default:default,org.eclipse.xtend.util.stdlib@default:default,org.eclipse.xtend2.lib@default:default,org.eclipse.xtend@default:default,org.eclipse.xtext.activities@default:default,org.eclipse.xtext.builder@default:default,org.eclipse.xtext.common.types.edit@default:default,org.eclipse.xtext.common.types.shared.jdt38@default:false,org.eclipse.xtext.common.types.shared@default:default,org.eclipse.xtext.common.types.ui@default:default,org.eclipse.xtext.common.types@default:default,org.eclipse.xtext.doc@default:default,org.eclipse.xtext.ecore@default:default,org.eclipse.xtext.generator@default:default,org.eclipse.xtext.junit4@default:default,org.eclipse.xtext.junit@default:default,org.eclipse.xtext.logging@default:false,org.eclipse.xtext.purexbase.ui@default:default,org.eclipse.xtext.purexbase@default:default,org.eclipse.xtext.smap@default:default,org.eclipse.xtext.ui.codetemplates.ui@default:default,org.eclipse.xtext.ui.codetemplates@default:default,org.eclipse.xtext.ui.ecore@default:default,org.eclipse.xtext.ui.junit@default:default,org.eclipse.xtext.ui.shared@default:default,org.eclipse.xtext.ui@default:default,org.eclipse.xtext.util@default:default,org.eclipse.xtext.xbase.junit@default:default,org.eclipse.xtext.xbase.lib*2.8.3.v201506010551@default:default,org.eclipse.xtext.xbase.lib*2.9.0.v201507170721@default:default,org.eclipse.xtext.xbase.lib.gwt@default:default,org.eclipse.xtext.xbase.ui@default:default,org.eclipse.xtext.xbase@default:default,org.eclipse.xtext.xtext.ui.examples@default:default,org.eclipse.xtext.xtext.ui.graph@default:default,org.eclipse.xtext.xtext.ui@default:default,org.eclipse.xtext@default:default,org.hamcrest.core@default:default,org.junit@default:default,org.objectweb.asm@default:default,org.sat4j.core@default:default,org.sat4j.pb@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="gov.ca.dwr.hecdssvue@default:default,gov.ca.dwr.jdiagram@default:default,gov.ca.dwr.wresl.xtext.editor.tests@default:default,gov.ca.dwr.wresl.xtext.editor.ui@default:default,gov.ca.dwr.wresl.xtext.editor@default:default,wrimsv2_plugin@default:default"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
+<stringAttribute key="timestamp" value="1391543995865"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="true"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>


### PR DESCRIPTION
Added launcher to wrims2 plugin folder<br>
Added readme with build instructions using Eclipse 4.4.2 as provided by DWR<br>
Proposed migration path
1. Update gov.ca.dwr.hecdssvue and gov.ca.dwr.jdiagram from java 6 to java 8 -- needed to migrate to newer IDE that supports gradle builds.
2. Migrate build to current IDE (Eclipse 2023-12) and current java 8 (1.8.0_391)
3. Create WRIMS Eclipse workspace/projects for WRIMS components with as much separation as dependencies will allow
4. Automate component package builds
5. Restructure build for assembled WRIMS
   1. Create install package that is separate from IDE install
      1. Remove WRIMS components from IDE install folder
      1. Move binaries to artifact manager?
    2. Automate build of install package -- preserving the update feature
3. Migrate components to Java 11.
4. Migrate to newer Java. 