### PR TITLE
add generated-src to the java source sets

### DIFF
--- a/wrims-core/build.gradle
+++ b/wrims-core/build.gradle
@@ -11,7 +11,7 @@ sourceSets {
             srcDir "src/main/antlr/"
         }
         java {
-            srcDir "src/main/java/"
+            srcDirs "src/main/java/", "generated-src"
         }
     }
 }


### PR DESCRIPTION
this allows the IDE to pick up generated-src as java files for debugging and development